### PR TITLE
use function call argument to force function call

### DIFF
--- a/example_segmentation.py
+++ b/example_segmentation.py
@@ -58,14 +58,15 @@ def segment(data: str) -> MultiSearch:
         model="gpt-3.5-turbo-0613",
         temperature=0,
         functions=[MultiSearch.openai_schema],
+        function_call={"name": MultiSearch.openai_schema['name']},
         messages=[
             {
                 "role": "system",
-                "content": "You must use the tool given to response.",
+                "content": "You are a helpful assistant.",
             },
             {
                 "role": "user",
-                "content": f"Consider the data below:\n{data} and segment it into multiple search queries. You must use `MultiStep` to do this.",
+                "content": f"Consider the data below:\n{data} and segment it into multiple search queries",
             },
         ],
         max_tokens=1000,


### PR DESCRIPTION
Hi, i think you can even improve the example by using the `function_call` argument to force the model using the provided functions/schema - see [documentation](https://platform.openai.com/docs/api-reference/chat/create#chat/create-function_call) and an example here: [Forcing the use of specific functions or no function](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_with_chat_models.ipynb) .

Works as expected and uses 15 tokens less in this short example ;-) .