### PR TITLE
Query planner prototype

### DIFF
--- a/question_answer_subquery.py
+++ b/question_answer_subquery.py
@@ -1,0 +1,123 @@
+import openai
+import enum
+import json
+
+from pydantic import Field
+from typing import List, Tuple
+from openai_function_call import OpenAISchema
+from tenacity import retry, stop_after_attempt
+
+
+class QueryType(str, enum.Enum):
+    """
+    Enumeration representing the types of queries that can be asked to a question answer system.
+    """
+
+    # When i call it anything beyond 'merge multiple responses' the accuracy drops significantly.
+    SINGLE_QUESTION = "SINGLE"
+    MERGE_MULTIPLE_RESPONSES = "MERGE_MULTIPLE_RESPONSES"
+
+
+class Query(OpenAISchema):
+    """
+    Class representing a single question in a question answer subquery.
+    Can be either a single question or a multi question merge.
+    """
+
+    id: int = Field(..., description="Unique id of the query")
+    question: str = Field(
+        ...,
+        description="Question we are asking using a question answer system, if we are asking multiple questions, this question is asked by also providing the answers to the sub questions",
+    )
+    dependancies: List[int] = Field(
+        default_factory=list,
+        description="List of sub questions that need to be answered before we can ask the question. Use a subquery when anything may be unknown, and we need to ask multiple questions to get the answer. Dependences must only be other queries.",
+    )
+    node_type: QueryType = Field(
+        default=QueryType.SINGLE_QUESTION,
+        description="Type of question we are asking, either a single question or a multi question merge when there are multiple questions",
+    )
+
+
+class QueryPlan(OpenAISchema):
+    """
+    Container class representing a tree of questions to ask a question answer system.
+    and its dependencies. Make sure every question is in the tree, and every question is asked only once.
+    """
+
+    query_graph: List[Query] = Field(
+        ..., description="The original question we are asking"
+    )
+
+
+Query.update_forward_refs()
+QueryPlan.update_forward_refs()
+
+
+def query_planner(question: str) -> QueryPlan:
+    PLANNING_MODEL = "gpt-4"
+    ANSWERING_MODEL = "gpt-3.5-turbo-0613"
+
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a world class query planning algorithm capable of breaking apart questions into its depenencies queries such that the answers can be used to inform the parent question. Do not answer the questions, simply provide correct compute graph with good specific questions to ask and relevant dependencies. Before you call the function, think step by step to get a better understanding the problem.",
+        },
+        {
+            "role": "user",
+            "content": f"Consider: {question}\n Before you call the function, think step by step to get a correct query plan.",
+        },
+        {
+            "role": "assistant",
+            "content": "Lets think step by step to find the correct query plan that does not make any assuptions of what is known.",
+        },
+    ]
+
+    completion = openai.ChatCompletion.create(
+        model=PLANNING_MODEL,
+        temperature=0,
+        messages=messages,
+        max_tokens=1000,
+    )
+
+    messages.append(completion.choices[0].message)
+
+    print(messages[-1])
+
+    messages.append(
+        {
+            "role": "user",
+            "content": "Using that information produce the complete and correct query plan.",
+        }
+    )
+
+    completion = openai.ChatCompletion.create(
+        model=ANSWERING_MODEL,
+        temperature=0,
+        functions=[QueryPlan.openai_schema],
+        function_call={"name": QueryPlan.openai_schema["name"]},
+        messages=messages,
+        max_tokens=1000,
+    )
+    root = QueryPlan.from_response(completion)
+    return root
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    plan = query_planner(
+        "What is the difference in populations of Canada and the Jason's home country?"
+    )
+    pprint(plan.dict())
+    """
+    {'question': {'dependancies': [{'dependancies': [],
+                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                                'question': 'What is the capital of Canada?'},
+                               {'dependancies': [],
+                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                                'question': "What is Jason's home country?"}],
+              'node_type': <QueryType.MERGE_MULTIPLE_RESPONSES: 'MERGE_MULTIPLE_RESPONSES'>,
+              'question': "What is of Canada and the Jason's "
+                          'home country?'}}
+    """

--- a/question_answer_subquery.py
+++ b/question_answer_subquery.py
@@ -82,8 +82,6 @@ def query_planner(question: str) -> QueryPlan:
 
     messages.append(completion.choices[0].message)
 
-    print(messages[-1])
-
     messages.append(
         {
             "role": "user",
@@ -111,13 +109,21 @@ if __name__ == "__main__":
     )
     pprint(plan.dict())
     """
-    {'question': {'dependancies': [{'dependancies': [],
-                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
-                                'question': 'What is the capital of Canada?'},
-                               {'dependancies': [],
-                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
-                                'question': "What is Jason's home country?"}],
-              'node_type': <QueryType.MERGE_MULTIPLE_RESPONSES: 'MERGE_MULTIPLE_RESPONSES'>,
-              'question': "What is of Canada and the Jason's "
-                          'home country?'}}
+    {'query_graph': [{'dependancies': [],
+                    'id': 1,
+                    'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                    'question': "Identify Jason's home country"},
+                    {'dependancies': [],
+                    'id': 2,
+                    'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                    'question': 'Find the population of Canada'},
+                    {'dependancies': [1],
+                    'id': 3,
+                    'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                    'question': "Find the population of Jason's home country"},
+                    {'dependancies': [2, 3],
+                    'id': 4,
+                    'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
+                    'question': 'Calculate the difference in populations between '
+                                "Canada and Jason's home country"}]}    
     """

--- a/question_answer_subquery.py
+++ b/question_answer_subquery.py
@@ -1,6 +1,6 @@
 import openai
 import enum
-import json
+import asyncio
 
 from pydantic import Field
 from typing import List, Tuple
@@ -16,6 +16,11 @@ class QueryType(str, enum.Enum):
     # When i call it anything beyond 'merge multiple responses' the accuracy drops significantly.
     SINGLE_QUESTION = "SINGLE"
     MERGE_MULTIPLE_RESPONSES = "MERGE_MULTIPLE_RESPONSES"
+
+
+class QueryAnswer(OpenAISchema):
+    question: str
+    answer: str
 
 
 class Query(OpenAISchema):
@@ -36,6 +41,10 @@ class Query(OpenAISchema):
     node_type: QueryType = Field(
         default=QueryType.SINGLE_QUESTION,
         description="Type of question we are asking, either a single question or a multi question merge when there are multiple questions",
+    )
+    original_question: bool = Field(
+        default=False,
+        description="the root question is the original question we are asking",
     )
 
 


### PR DESCRIPTION
# Learnings from the Prototype - First Version

## Problem: Recursion Breaks Down at Deep Nesting
- **Solution:** Implement flat tasks with indices and dependencies that reference the indices instead of using recursion.
- **Risks:** Possibility of hallucinations. of indicies (but cot could make that a bit better)

## Problem: Dependency Order is Not Fully Known, Causing Confusion sometimes
- **Solution:** Use two calls instead of one. The first call is for planning with CoT (Context of Task), and the second call is to translate the plan into a schema. 
- **Thoughts:** its not needed, can work with one on simple problems, Although less impressive, this solution works well. It can leverage GPT-4 for planning and GPT-3.5 for translation. Alternatively, using only GPT-4 in a single call is possible, but it often tries to be overly smart and ends up breaking the schema. 
- The idea of using flat tasks with indices originated from GPT-4 breaking my schema which lead to me reconsidering if my schema was good. 
- Generally if GPT-4 breaks schemas i'm considering it feedback and changing my schemas. (Weird)

## Problem: Naming is Crucial, Renaming "Multi Merge" Disrupted Functionality
- **Solution:** Put more thought into naming and apply prompt engineering best practices.
- **Thoughts:** As variable names act as step functions in terms of successful tasks, prompt engineering will be crucial for some time.

## Other Notes:
- Saying complete and correct does better than not saying it
- alphabetization of attributes determines the order of completions which may change performance
- CoT helps, but i can't get it to complete messages and the function call in the same api call, there must be a way to get message.content and message.function_call in one api call. since it  doubles the price of my prompt tokens 