### PR TITLE
make schema and query planning more general

### DIFF
--- a/question_answer_subquery.py
+++ b/question_answer_subquery.py
@@ -8,45 +8,29 @@ from openai_function_call import OpenAISchema
 from tenacity import retry, stop_after_attempt
 
 
-class QueryType(str, enum.Enum):
-    """
-    Enumeration representing the types of queries that can be asked to a question answer system.
-    """
-
-    # When i call it anything beyond 'merge multiple responses' the accuracy drops significantly.
-    SINGLE_QUESTION = "SINGLE"
-    MERGE_MULTIPLE_RESPONSES = "MERGE_MULTIPLE_RESPONSES"
-
-
 class Query(OpenAISchema):
     """
-    Class representing a single question in a question answer subquery.
-    Can be either a single question or a multi question merge.
+    Class representing a single query in a query plan.
     """
 
     id: int = Field(..., description="Unique id of the query")
-    question: str = Field(
+    query: str = Field(
         ...,
-        description="Question we are asking using a question answer system, if we are asking multiple questions, this question is asked by also providing the answers to the sub questions",
+        description="Contains the query in text form. If there are multiple queries, this query can only be answered when all dependant subqueries have been answered.",
     )
-    dependancies: List[int] = Field(
+    subqueries: List[int] = Field(
         default_factory=list,
-        description="List of sub questions that need to be answered before we can ask the question. Use a subquery when anything may be unknown, and we need to ask multiple questions to get the answer. Dependences must only be other queries.",
+        description="List of the IDs of subqueries that need to be answered before we can answer the main question. Use a subquery when anything may be unknown and we need to ask multiple questions to get the answer. Dependencies must only be other queries.",
     )
-    node_type: QueryType = Field(
-        default=QueryType.SINGLE_QUESTION,
-        description="Type of question we are asking, either a single question or a multi question merge when there are multiple questions",
-    )
-
 
 class QueryPlan(OpenAISchema):
     """
-    Container class representing a tree of questions to ask a question answer system.
-    and its dependencies. Make sure every question is in the tree, and every question is asked only once.
+    Container class representing a tree of queries and subqueries.
+    Make sure every task is in the tree, and every task is done only once.
     """
 
     query_graph: List[Query] = Field(
-        ..., description="The original question we are asking"
+        ..., description="List of queries and subqueries that need to be done to complete the main query. Consists of the main query and its dependencies."
     )
 
 
@@ -55,44 +39,20 @@ QueryPlan.update_forward_refs()
 
 
 def query_planner(question: str) -> QueryPlan:
-    PLANNING_MODEL = "gpt-4"
-    ANSWERING_MODEL = "gpt-3.5-turbo-0613"
 
     messages = [
         {
             "role": "system",
-            "content": "You are a world class query planning algorithm capable of breaking apart questions into its depenencies queries such that the answers can be used to inform the parent question. Do not answer the questions, simply provide correct compute graph with good specific questions to ask and relevant dependencies. Before you call the function, think step by step to get a better understanding the problem.",
+            "content": "You are a world class query planning algorithm capable of breaking apart queries into dependant subqueries, such that the answers can be used to enable the system completing the main query. Do not complete the user query, simply provide a correct compute graph with good specific queries to ask and relevant subqueries. Before completing the list of queries, think step by step to get a better understanding the problem.",
         },
         {
             "role": "user",
-            "content": f"Consider: {question}\n Before you call the function, think step by step to get a correct query plan.",
-        },
-        {
-            "role": "assistant",
-            "content": "Lets think step by step to find the correct query plan that does not make any assuptions of what is known.",
+            "content": f"{question}",
         },
     ]
 
     completion = openai.ChatCompletion.create(
-        model=PLANNING_MODEL,
-        temperature=0,
-        messages=messages,
-        max_tokens=1000,
-    )
-
-    messages.append(completion.choices[0].message)
-
-    print(messages[-1])
-
-    messages.append(
-        {
-            "role": "user",
-            "content": "Using that information produce the complete and correct query plan.",
-        }
-    )
-
-    completion = openai.ChatCompletion.create(
-        model=ANSWERING_MODEL,
+        model="gpt-4-0613",
         temperature=0,
         functions=[QueryPlan.openai_schema],
         function_call={"name": QueryPlan.openai_schema["name"]},
@@ -111,13 +71,69 @@ if __name__ == "__main__":
     )
     pprint(plan.dict())
     """
-    {'question': {'dependancies': [{'dependancies': [],
-                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
-                                'question': 'What is the capital of Canada?'},
-                               {'dependancies': [],
-                                'node_type': <QueryType.SINGLE_QUESTION: 'SINGLE'>,
-                                'question': "What is Jason's home country?"}],
-              'node_type': <QueryType.MERGE_MULTIPLE_RESPONSES: 'MERGE_MULTIPLE_RESPONSES'>,
-              'question': "What is of Canada and the Jason's "
-                          'home country?'}}
+    > {'query_graph': [{'id': 1,
+                      'query': 'What is the population of Canada?',
+                      'subqueries': []},
+                     {'id': 2,
+                      'query': "What is Jason's home country?",
+                      'subqueries': []},
+                     {'id': 3,
+                      'query': "What is the population of Jason's home country?",
+                      'subqueries': [2]},
+                     {'id': 4,
+                      'query': 'What is the difference in populations of Canada '
+                               "and the Jason's home country?",
+                      'subqueries': [1, 3]}]}
+                      
+    plan = query_planner(
+    "Write a pitch presentation to promote my startup to VC investors!"
+    )
+    pprint(plan.dict())
+    
+    > {'query_graph': [{'id': 1,
+                  'query': 'What is the name of the startup?',
+                  'subqueries': []},
+                 {'id': 2,
+                  'query': 'What is the mission of the startup?',
+                  'subqueries': []},
+                 {'id': 3,
+                  'query': 'What problem does the startup solve?',
+                  'subqueries': []},
+                 {'id': 4,
+                  'query': 'What is the unique selling proposition (USP) of '
+                           'the startup?',
+                  'subqueries': []},
+                 {'id': 5,
+                  'query': 'Who are the target customers of the startup?',
+                  'subqueries': []},
+                 {'id': 6,
+                  'query': "What is the market size for the startup's product "
+                           'or service?',
+                  'subqueries': []},
+                 {'id': 7,
+                  'query': 'Who are the competitors of the startup and how '
+                           'does the startup differentiate itself?',
+                  'subqueries': []},
+                 {'id': 8,
+                  'query': 'What is the business model of the startup?',
+                  'subqueries': []},
+                 {'id': 9,
+                  'query': 'What is the current financial status of the '
+                           'startup?',
+                  'subqueries': []},
+                 {'id': 10,
+                  'query': 'What is the growth plan of the startup?',
+                  'subqueries': []},
+                 {'id': 11,
+                  'query': 'What is the funding requirement and how will the '
+                           'funds be used?',
+                  'subqueries': []},
+                 {'id': 12,
+                  'query': 'Who are the team members and what are their '
+                           'backgrounds?',
+                  'subqueries': []},
+                 {'id': 13,
+                  'query': 'Write a pitch presentation to promote the startup '
+                           'to VC investors',
+                  'subqueries': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}]}
     """


### PR DESCRIPTION
Don't really know whether it makes sense to merge because it alters the example quite a lot (and still doesn't work really well with 3.5), feel free to edit or just ignore/close.

However I found this generalizes on you example well and works for queries beyond simple questions and is more reliable and uses less tokens than your example.

Imho it makes more sense to let the model only figure out direct dependencies and then parse the dependency graph programatically?

