### PR TITLE
slimmer openai function signature

### DIFF
--- a/openai_function_call.py
+++ b/openai_function_call.py
@@ -46,6 +46,7 @@ class openai_function:
             for k, v in parameters["properties"].items()
             if k not in ("v__duplicate_kwargs", "args", "kwargs")
         }
+        parameters['required']=sorted(parameters['properties']) #bug workaround see lc
         _remove_a_key(parameters, "title")
         _remove_a_key(parameters, "additionalProperties")
         self.openai_schema = {
@@ -85,6 +86,7 @@ class OpenAISchema(BaseModel):
         parameters = {
             k: v for k, v in schema.items() if k not in ("title", "description")
         }
+        parameters['required']=sorted(parameters['properties'])
         _remove_a_key(parameters, "title")
         return {
             "name": schema["title"],

--- a/openai_function_call.py
+++ b/openai_function_call.py
@@ -26,14 +26,32 @@ from typing import Any, Callable
 from pydantic import validate_arguments, BaseModel
 
 
+def _remove_a_key(d, remove_key) -> None:
+    """Remove a key from a dictionary recursively"""
+    if isinstance(d, dict):
+        for key in list(d.keys()):
+            if key == remove_key:
+                del d[key]
+            else:
+                _remove_a_key(d[key], remove_key)
+
+
 class openai_function:
     def __init__(self, func: Callable) -> None:
         self.func = func
         self.validate_func = validate_arguments(func)
+        parameters = self.validate_func.model.schema()
+        parameters["properties"] = {
+            k: v
+            for k, v in parameters["properties"].items()
+            if k not in ("v__duplicate_kwargs", "args", "kwargs")
+        }
+        _remove_a_key(parameters, "title")
+        _remove_a_key(parameters, "additionalProperties")
         self.openai_schema = {
             "name": self.func.__name__,
             "description": self.func.__doc__,
-            "parameters": self.validate_func.model.schema(),
+            "parameters": parameters,
         }
         self.model = self.validate_func.model
 
@@ -64,10 +82,14 @@ class OpenAISchema(BaseModel):
     @property
     def openai_schema(cls):
         schema = cls.schema()
+        parameters = {
+            k: v for k, v in schema.items() if k not in ("title", "description")
+        }
+        _remove_a_key(parameters, "title")
         return {
             "name": schema["title"],
             "description": schema["description"],
-            "parameters": schema,
+            "parameters": parameters,
         }
 
     @classmethod


### PR DESCRIPTION
Don't want to bother you ;-) - but as I use the `OpenAISchema` quite a lot maybe you can also make use of these small improvements.

This looks a bit hacky (feel free to edit, I didn't find a better solution to edit the pydantic json schema output) but makes the function signatures a lot cleaner - in my tests this made function calls more reliable (as it is closer to the finetuned function signatures - see e.g. [here](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_for_knowledge_retrieval.ipynb) for reference) and uses less tokens:

```python
@openai_function
def test(a:int=1, b:str="a"):
    """test"""
    pass
print(test.openai_schema)
print()
class Test(OpenAISchema):
    """test"""
    a:int=1
    b:str="a"
print(Test.openai_schema)
```

on main:

```
{'description': 'test',
 'name': 'test',
 'parameters': {'additionalProperties': False,
                'properties': {'a': {'default': 1,
                                     'title': 'A',
                                     'type': 'integer'},
                               'args': {'items': {},
                                        'title': 'Args',
                                        'type': 'array'},
                               'b': {'default': 'a',
                                     'title': 'B',
                                     'type': 'string'},
                               'kwargs': {'title': 'Kwargs', 'type': 'object'},
                               'v__duplicate_kwargs': {'items': {'type': 'string'},
                                                       'title': 'V  Duplicate '
                                                                'Kwargs',
                                                       'type': 'array'}},
                'title': 'Test',
                'type': 'object'}}

{'description': 'test',
 'name': 'Test',
 'parameters': {'description': 'test',
                'properties': {'a': {'default': 1,
                                     'title': 'A',
                                     'type': 'integer'},
                               'b': {'default': 'a',
                                     'title': 'B',
                                     'type': 'string'}},
                'title': 'Test',
                'type': 'object'}}
```

with these changes:
```
{'description': 'test',
 'name': 'test',
 'parameters': {'properties': {'a': {'default': 1, 'type': 'integer'},
                               'b': {'default': 'a', 'type': 'string'}},
                'type': 'object'}}

{'description': 'test',
 'name': 'Test',
 'parameters': {'properties': {'a': {'default': 1, 'type': 'integer'},
                               'b': {'default': 'a', 'type': 'string'}},
                'type': 'object'}}
```

