### PR TITLE
Added example directory and fixed broken imports

### DIFF
--- a/examples/citation_fuzzy_match/citation_fuzzy_match.py
+++ b/examples/citation_fuzzy_match/citation_fuzzy_match.py
@@ -1,6 +1,14 @@
-import openai
+import sys
+from os.path import abspath, dirname
 from typing import List
+
+import openai
 from pydantic import Field, BaseModel
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
 from openai_function_call import OpenAISchema
 
 

--- a/examples/parse_recursive_paths/parse_recursive_paths.py
+++ b/examples/parse_recursive_paths/parse_recursive_paths.py
@@ -40,13 +40,20 @@ Example usage:
 # >>> root/folder2/subfolder1/file4.txt     NodeType.FILE
 """
 
-import openai
 import enum
-
-from pydantic import Field
+import sys
+from os.path import abspath, dirname
 from typing import List
-from openai_function_call import OpenAISchema
+
+import openai
+from pydantic import Field
 from tenacity import retry, stop_after_attempt
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
+from openai_function_call import OpenAISchema
 
 
 class NodeType(str, enum.Enum):

--- a/examples/query_planner_execution/query_planner_execution.py
+++ b/examples/query_planner_execution/query_planner_execution.py
@@ -1,14 +1,17 @@
-from functools import lru_cache
-import openai
-import enum
-import json
 import asyncio
+import enum
+import sys
+from os.path import abspath, dirname
+from typing import List
 
+import openai
 from pydantic import Field
-from typing import List, Tuple
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
 from openai_function_call import OpenAISchema
-from tenacity import retry, stop_after_attempt
-from pprint import pprint
 
 
 class QueryType(str, enum.Enum):

--- a/examples/safe_sql/safe_sql.py
+++ b/examples/safe_sql/safe_sql.py
@@ -1,8 +1,16 @@
-from openai_function_call import OpenAISchema
-from pydantic import Field
-from typing import Any, List
-import openai
 import enum
+import sys
+from os.path import abspath, dirname
+from typing import Any, List
+
+import openai
+from pydantic import Field
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
+from openai_function_call import OpenAISchema
 
 
 class SQLTemplateType(str, enum.Enum):

--- a/examples/segment_search_queries/segment_search_queries.py
+++ b/examples/segment_search_queries/segment_search_queries.py
@@ -16,12 +16,20 @@ Examples:
 # >>> Searching for `Documents` with query `GPDR policy` using `SearchType.EMAIL`
 """
 
-from openai_function_call import OpenAISchema
-from pydantic import Field
-from typing import List
-from tenacity import retry, stop_after_attempt
-import openai
 import enum
+import sys
+from os.path import abspath, dirname
+from typing import List
+
+import openai
+from pydantic import Field
+from tenacity import retry, stop_after_attempt
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
+from openai_function_call import OpenAISchema
 
 
 class SearchType(str, enum.Enum):

--- a/examples/task_planner_topological_sort/task_planner_topological_sort.py
+++ b/examples/task_planner_topological_sort/task_planner_topological_sort.py
@@ -10,10 +10,18 @@ we will wait unnecessarily with my current implementation.
 Added by Jan Philipp Harries / @jpdus
 """
 
-import openai
 import asyncio
-from pydantic import Field, BaseModel
+import sys
+from os.path import abspath, dirname
 from typing import List, Generator
+
+import openai
+from pydantic import Field, BaseModel
+
+# Add the root directory of your project to the Python import search path
+root_dir = dirname(dirname(dirname(abspath(__file__))))
+sys.path.append(root_dir)
+
 from openai_function_call import OpenAISchema
 
 


### PR DESCRIPTION
I added this block of code to all the examples. I couldn't come up with a fancier solution.

```python3
root_dir = dirname(dirname(dirname(abspath(__file__))))
sys.path.append(root_dir)

from openai_function_call import OpenAISchema
```

Also, there were some unused imports from `query_planner_execution.py` which I removed to make it cleaner