### PR TITLE
warning for v > 3.9, correct package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Follow me on twitter and consider helping pay for openai tokens!
 
 ## Installation
 
+Ensure you have Python version 3.9 or above.
+
 ```python
-pip install openai_function_call
+pip install openai-function-call
 ```
 
 ## Contributing


### PR DESCRIPTION
adds a warning to ensure python v > 3.9, 
correct name of pip package as per PyPI.