### PR TITLE
Excluding properties with defaults from required as per issue #41

### DIFF
--- a/openai_function_call/function_calls.py
+++ b/openai_function_call/function_calls.py
@@ -72,8 +72,9 @@ class openai_function:
             if k not in ("v__duplicate_kwargs", "args", "kwargs")
         }
         parameters["required"] = sorted(
-            parameters["properties"]
-        )  # bug workaround see lc
+            k for k, v in parameters["properties"].items() 
+            if not "default" in v
+        )
         _remove_a_key(parameters, "additionalProperties")
         self.openai_schema = {
             "name": self.func.__name__,
@@ -130,7 +131,10 @@ class OpenAISchema(BaseModel):
         parameters = {
             k: v for k, v in schema.items() if k not in ("title", "description")
         }
-        parameters["required"] = sorted(parameters["properties"])
+        parameters["required"] = sorted(
+            k for k, v in parameters["properties"].items() 
+            if not "default" in v
+        )
 
         if "description" not in schema:
             schema[


### PR DESCRIPTION
## Summary
This pull request addresses issue #41 "Exclude properties with defaults from required." 

## Changes
- Modified the code to exclude properties with defined default values from the `required` field in the parameters dictionary
- This change provides more flexibility when dealing with properties that have default values
- By setting this default to "None" this allows us to use optional data 