### PR TITLE
Allow less strict JSON parsing

### DIFF
--- a/openai_function_call/function_calls.py
+++ b/openai_function_call/function_calls.py
@@ -109,7 +109,7 @@ class openai_function:
             ), "Function name does not match"
 
         function_call = message["function_call"]
-        arguments = json.loads(function_call["arguments"])
+        arguments = json.loads(function_call["arguments"], strict=False)
         return self.validate_func(**arguments)
 
 
@@ -163,7 +163,7 @@ class OpenAISchema(BaseModel):
             ), "Function name does not match"
 
         function_call = message["function_call"]
-        arguments = json.loads(function_call["arguments"])
+        arguments = json.loads(function_call["arguments"], strict=False)
         return cls(**arguments)
 
 


### PR DESCRIPTION
When getting longform answers from OpenAI that contains newlines or tabs, the string returned doesn't have escaped control characters.

`strict=False` allows parsing of these strings with control characters, with character codes in the 0-31 range, including '\t' (tab), '\n', '\r' and '\0'."